### PR TITLE
workflow: pass secrets via env vars to avoid shell quoting issues

### DIFF
--- a/.github/workflows/run-python.yml
+++ b/.github/workflows/run-python.yml
@@ -33,10 +33,12 @@ jobs:
         run: echo "$GDRIVE_CREDENTIALS" > auth.json
 
       - name: 🍪 Setup Cookies
-        if: ${{ secrets.COOKIES != '' }}
         env:
           COOKIES_B64: ${{ secrets.COOKIES }}
-        run: echo "$COOKIES_B64" | base64 -d > cookies.txt
+        run: |
+          if [ -n "$COOKIES_B64" ]; then
+            echo "$COOKIES_B64" | base64 -d > cookies.txt
+          fi
 
       - name: ⚙️ Run install
         run: ./install.sh

--- a/.github/workflows/run-python.yml
+++ b/.github/workflows/run-python.yml
@@ -28,11 +28,15 @@ jobs:
           " "${{ github.event.inputs.title }}" "${{ github.event.inputs.link }}" > data.json
 
       - name: 🔑 Create Google Credentials File
-        run: echo '${{ secrets.GDRIVE_CREDENTIALS }}' > auth.json
+        env:
+          GDRIVE_CREDENTIALS: ${{ secrets.GDRIVE_CREDENTIALS }}
+        run: echo "$GDRIVE_CREDENTIALS" > auth.json
 
       - name: 🍪 Setup Cookies
         if: ${{ secrets.COOKIES != '' }}
-        run: echo '${{ secrets.COOKIES }}' | base64 -d > cookies.txt
+        env:
+          COOKIES_B64: ${{ secrets.COOKIES }}
+        run: echo "$COOKIES_B64" | base64 -d > cookies.txt
 
       - name: ⚙️ Run install
         run: ./install.sh


### PR DESCRIPTION
Inline ${{ secrets.X }} inside single-quoted echo commands breaks if the secret value contains a single quote. Pass secrets as env vars instead so the shell never interpolates them directly.

https://claude.ai/code/session_014y5pZHaJJyJEBdgxAiqPMz